### PR TITLE
Handle Filenames With Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ pdf2png.js
 Install:
 npm install pdf2png-mp2
 
-This is a fork of an exsiitn module known as pdf2png-mp.  This update allows filenames with spaces to be processed.
+***Credit for this module should go to to @nkognitoo***
+
+This is a fork of an exsiitn module known as pdf2png-mp: https://www.npmjs.com/package/pdf2png-mp.  This update allows filenames with spaces to be processed.  
 
 This project uses ghostscript, but there's no need to install it (if you use windows).
 If you want the module to use a local installation of ghostscript, set the option useLocalGhostscript true.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ pdf2png.js
 ============
 
 Install:
-npm install pdf2png
+npm install pdf2png-mp2
+
+This is a fork of an exsiitn module known as pdf2png-mp.  This update allows filenames with spaces to be processed.
 
 This project uses ghostscript, but there's no need to install it (if you use windows).
 If you want the module to use a local installation of ghostscript, set the option useLocalGhostscript true.

--- a/lib/pdf2png.js
+++ b/lib/pdf2png.js
@@ -3,6 +3,8 @@ var tmp = require('tmp');
 var fs = require('fs');
 var filesource = require('filesource');
 
+var pdfPageCount = require('pdf_page_count');
+
 var initialized = false;
 
 // Add Ghostscript executables path
@@ -15,13 +17,56 @@ exports.ghostscriptPath = projectPath + "\\executables\\ghostScript";
 // for linux compability
 exports.ghostscriptPath = exports.ghostscriptPath.split("\\").join("/");
 
+function getPageCount(callback, filepathOrData) {
+	pdfPageCount.count(filepathOrData, function(resp2){
+		if(!resp2.success)
+		{
+			console.log("Something went wrong: " + resp2.error);
+
+			return;
+		}
+		callback(resp2);
+	});
+};
+
+
+function getImage(callback, options, imageFilepath, resp, i){
+	console.log(imageFilepath);
+	console.log(resp.data);
+	exec("gs -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -sDEVICE=png16m -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r" + options.quality + " -dFirstPage="+i+" -dLastPage="+i+" -sOutputFile=" + imageFilepath + " " + '"' + resp.data + '"', function (error, stdout, stderr) {
+		// Remove temp files
+		resp.clean();
+
+		if(error !== null)
+		{
+			callback({ success: false, error: "Error converting pdf to png: " + error });
+			return;
+		}
+
+		if(options.returnFilePath)
+		{
+			callback({ success: true, data: imageFilepath });
+			return;
+		}
+
+		var img = fs.readFileSync(imageFilepath);
+
+		// Remove temp file
+		fs.unlink(imageFilepath);
+
+		callback({ success: true, data: img, number: i });
+	});
+
+}
+
 exports.convert = function() {
+
 	var filepathOrData = arguments[0];
 	var callback = arguments[1];
 	var options = {};
 	
 	var tmpFileCreated = false;
-	
+
 	if(arguments[2] != null)
 	{
 		options = arguments[1];
@@ -37,7 +82,7 @@ exports.convert = function() {
 		
 		initialized = true;
 	}
-	
+
 	options.quality = options.quality || 100;
 	
 	filesource.getDataPath(filepathOrData, function(resp){
@@ -46,38 +91,42 @@ exports.convert = function() {
 			callback(resp);
 			return;
 		}
-		
-		// get temporary filepath
-		tmp.file({ postfix: ".png" }, function(err, imageFilepath, fd) {
-			if(err)
-			{
-				callback({ success: false, error: "Error getting second temporary filepath: " + err });
-				return;
+
+		getPageCount(function(resp2) {
+			// get temporary filepath
+
+
+			for(var i = 1; i <= resp2.data; i++){
+
+				var result = new Object();
+				result.data = [];
+
+				var foo = 0;
+				var bar = 0;
+				var her = 1;
+				foo = resp2.data;
+
+				tmp.file({ postfix: ".png" }, function(err, imageFilepath, fd) {
+
+					if(err)
+					{
+						callback({ success: false, error: "Error getting second temporary filepath: " + err });
+						return;
+					}
+
+					getImage(function(resp3){
+						//result.data.push(resp3.data);
+						result.data[resp3.number] = resp3.data;
+						result.success = resp3.success;
+						bar++;
+						if(foo == bar)
+							callback(result)
+					}, options, imageFilepath, resp, her++)
+				});
+
+
 			}
-			
-			exec("gs -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -sDEVICE=png16m -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r" + options.quality + " -dFirstPage=1 -dLastPage=1 -sOutputFile=" + imageFilepath + " " + resp.data, function (error, stdout, stderr) {
-				// Remove temp files
-				resp.clean();
-				
-				if(error !== null)
-				{
-					callback({ success: false, error: "Error converting pdf to png: " + error });
-					return;
-				}
-				
-				if(options.returnFilePath)
-				{
-					callback({ success: true, data: imageFilepath });
-					return;
-				}
-				
-				var img = fs.readFileSync(imageFilepath);
-				
-				// Remove temp file
-				fs.unlink(imageFilepath);
-				
-				callback({ success: true, data: img });
-			});
-		});
+		}, filepathOrData);
+
 	});
 };

--- a/lib/pdf2png.js
+++ b/lib/pdf2png.js
@@ -31,8 +31,6 @@ function getPageCount(callback, filepathOrData) {
 
 
 function getImage(callback, options, imageFilepath, resp, i){
-	console.log(imageFilepath);
-	console.log(resp.data);
 	exec("gs -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -sDEVICE=png16m -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r" + options.quality + " -dFirstPage="+i+" -dLastPage="+i+" -sOutputFile=" + imageFilepath + " " + '"' + resp.data + '"', function (error, stdout, stderr) {
 		// Remove temp files
 		resp.clean();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-	"name":			"pdf2png",
-	"version":		"1.0.5",
+	"name":			"pdf2png-mp2",
+	"version":		"1.0.3",
 	"description":	"Takes a PDF-document and converts and delivers a PNG",
 	"engine":		"node >= 0.6.0",
 	"main":			"./lib/pdf2png.js",
 	"dependencies": {
         "tmp":			"0.0.23",
+        "pdf_page_count": "^1.0.10",
         "filesource":	"latest"
 	},
 	"repository" :


### PR DESCRIPTION
Encapsulate filenames with spaces in double quotes on resp.data (line
58).

was:
exec("gs -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -sDEVICE=png16m -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r" + options.quality + " -dFirstPage=1 -dLastPage=1 -sOutputFile=" + imageFilepath + " " + resp.data, function (error, stdout, stderr) {

is now:
exec("gs -dQUIET -dPARANOIDSAFER -dBATCH -dNOPAUSE -dNOPROMPT -sDEVICE=png16m -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -r" + options.quality + " -dFirstPage="+i+" -dLastPage="+i+" -sOutputFile=" + imageFilepath + " " + '"' + resp.data + '"', function (error, stdout, stderr) {
